### PR TITLE
feat(anime): integrate Jikan API with dynamic homepage & browse pages

### DIFF
--- a/aniwatch(Rework-Jikarti)/aniwatch/src/main/java/com/aniwatch/aniwatch/HomeController.java
+++ b/aniwatch(Rework-Jikarti)/aniwatch/src/main/java/com/aniwatch/aniwatch/HomeController.java
@@ -1,4 +1,7 @@
 package com.aniwatch.aniwatch;
+
+import com.aniwatch.aniwatch.anime.Anime;
+import com.aniwatch.aniwatch.anime.AnimeService;
 import com.aniwatch.aniwatch.user.*;
 import com.aniwatch.aniwatch.watchlist.*;
 
@@ -21,6 +24,9 @@ public class HomeController {
 
     @Autowired
     private UserService userService;
+
+    @Autowired
+    private AnimeService animeService;
 
     @GetMapping("/")
     public String redirectToHome(
@@ -68,6 +74,13 @@ public class HomeController {
         return "redirect:" + redirectUrl.toString();
     }
 
+    // This is the http GET request you put in your browser to access the home page
+    // It will redirect to the home page and show the login modal if specified in
+    // the URL
+    // e.g. http://localhost:8080/home?showLoginModal=true&loginError=true
+    // This is the home page of the website, where you can see a few random
+    // watchlists
+
     @GetMapping("/home")
     public String home(
             @RequestParam(value = "showLoginModal", required = false) Boolean showLoginModal,
@@ -95,22 +108,30 @@ public class HomeController {
             model.addAttribute("registered", true);
         }
 
-        // Something extra to determine current season ;-)
+        // 1) Compute season + year
         LocalDate today = LocalDate.now();
+        int year = today.getYear();
         int month = today.getMonthValue();
-
         String currentSeason;
-        if (month >= 1 && month <= 3) {
+        if (month <= 3) {
             currentSeason = "Winter";
-        } else if (month >= 4 && month <= 6) {
+        } else if (month <= 6) {
             currentSeason = "Spring";
-        } else if (month >= 7 && month <= 9) {
+        } else if (month <= 9) {
             currentSeason = "Summer";
         } else {
             currentSeason = "Fall";
         }
-
+        // add for display
         model.addAttribute("currentSeason", currentSeason);
+
+        // 2) Fetch (but don’t save) seasonal anime
+        List<Anime> seasonalAnime = animeService.fetchSeasonalAnime(
+                year,
+                currentSeason, // e.g. "Summer"
+                20 // limit
+        );
+        model.addAttribute("seasonalAnime", seasonalAnime);
 
         return "home";
     }

--- a/aniwatch(Rework-Jikarti)/aniwatch/src/main/java/com/aniwatch/aniwatch/anime/Anime.java
+++ b/aniwatch(Rework-Jikarti)/aniwatch/src/main/java/com/aniwatch/aniwatch/anime/Anime.java
@@ -10,6 +10,9 @@ public class Anime {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "mal_id", unique = true, nullable = false)
+    private Long externalId;             // the Jikan mal_id
+
     @Column(nullable = false)
     private String title;
 
@@ -48,4 +51,8 @@ public class Anime {
     public void setImageUrl(String imageUrl) {
         this.imageUrl = imageUrl;
     }
+    
+        // getters & setters
+        public Long getExternalId() { return externalId; }
+        public void setExternalId(Long externalId) { this.externalId = externalId; }
 }

--- a/aniwatch(Rework-Jikarti)/aniwatch/src/main/java/com/aniwatch/aniwatch/anime/AnimeController.java
+++ b/aniwatch(Rework-Jikarti)/aniwatch/src/main/java/com/aniwatch/aniwatch/anime/AnimeController.java
@@ -1,6 +1,9 @@
 package com.aniwatch.aniwatch.anime;
 
 import com.aniwatch.aniwatch.user.UserService;
+
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -21,32 +24,24 @@ public class AnimeController {
 
     @GetMapping
     public String browseAnime(Model model) {
-        // To eventually check for sample data
-        animeService.initializeSampleData();
+        // 1) Fetch & save API results
+        List<Anime> animeList = animeService.fetchAndSaveTopAnime();
+        model.addAttribute("animeList", animeList);
 
-        // Get all anime
-        model.addAttribute("animeList", animeService.getAllAnime());
-
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        boolean isAuthenticated = authentication != null &&
-                authentication.isAuthenticated() &&
-                !authentication.getName().equals("anonymousUser");
-
-        model.addAttribute("isAuthenticated", isAuthenticated);
-
-        if (isAuthenticated) {
-            String username = authentication.getName();
+        // 2) Your existing auth & userService logic...
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        boolean isAuth = auth != null && auth.isAuthenticated()
+                         && !"anonymousUser".equals(auth.getName());
+        model.addAttribute("isAuthenticated", isAuth);
+        if (isAuth) {
+            String username = auth.getName();
             model.addAttribute("username", username);
-
             boolean isProvider = userService.isProvider(username);
             model.addAttribute("isProvider", isProvider);
-
             if (isProvider) {
-                Long providerId = userService.getProviderId(username);
-                model.addAttribute("providerId", providerId);
+                model.addAttribute("providerId", userService.getProviderId(username));
             }
         }
-
         return "browse-anime";
     }
 }

--- a/aniwatch(Rework-Jikarti)/aniwatch/src/main/java/com/aniwatch/aniwatch/anime/AnimeService.java
+++ b/aniwatch(Rework-Jikarti)/aniwatch/src/main/java/com/aniwatch/aniwatch/anime/AnimeService.java
@@ -1,43 +1,131 @@
 package com.aniwatch.aniwatch.anime;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
 
-import java.util.List;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Service
 public class AnimeService {
 
-    @Autowired
-    private AnimeRepository animeRepository;
+    private static final String JIKAN_API = "https://api.jikan.moe/v4/anime?limit=20&sfw=true";
 
-    public List<Anime> getAllAnime() {
-        return animeRepository.findAll();
+    private static final String SEASON_URL_TEMPLATE = "https://api.jikan.moe/v4/seasons/%d/%s?limit=20&sfw=true&rating=pg-13";
+
+    private final AnimeRepository animeRepository;
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Autowired
+    public AnimeService(AnimeRepository repo, RestTemplate rt, ObjectMapper om) {
+        this.animeRepository = repo;
+        this.restTemplate = rt;
+        this.objectMapper = om;
+    }
+
+    /**
+     * Fetches (but does NOT save) up to `limit` anime for the given year+season.
+     */
+    public List<Anime> fetchSeasonalAnime(int year, String season, int limit) {
+        try {
+            // Build the URL using your new constant
+            String url = String.format(SEASON_URL_TEMPLATE, year, season.toLowerCase());
+
+            // Call the Jikan API
+            String json = restTemplate.getForObject(url, String.class);
+
+            // Parse the "data" array
+            JsonNode data = objectMapper.readTree(json).path("data");
+
+            // Map each node to an Anime (but don’t save), limiting to `limit`
+            return StreamSupport.stream(data.spliterator(), false)
+                    .limit(limit)
+                    .map(this::mapNodeToAnime)
+                    .collect(Collectors.toList());
+
+        } catch (JsonProcessingException e) {
+            // Log and return empty fallback on parse errors
+            System.err.println("Error fetching seasonal anime: " + e.getMessage());
+            return List.of();
+        }
+    }
+
+    /** Helper to turn a single JSON node into an Anime instance. */
+    private Anime mapNodeToAnime(JsonNode node) {
+        Anime a = new Anime();
+
+        // Title (fallback to the canonical "title" if English is missing)
+        String eng = node.path("title_english").asText(null);
+        String fallback = node.path("title").asText("Untitled");
+        a.setTitle((eng != null && !eng.isEmpty()) ? eng : fallback);
+
+        // Alternate title and image URL
+        a.setAlternateTitle(node.path("title_japanese").asText(""));
+        a.setImageUrl(node.path("images")
+                .path("webp")
+                .path("large_image_url")
+                .asText());
+
+        return a;
+    }
+
+    /**
+     * Fetches up to 20 anime from Jikan, saves each into the DB, and returns the
+     * list.
+     */
+    public List<Anime> fetchAndSaveTopAnime() {
+        try {
+            String json = restTemplate.getForObject(JIKAN_API, String.class);
+            JsonNode data = objectMapper.readTree(json).path("data");
+
+            List<Anime> animeList =
+                    // stream over the first 20 entries
+                    toList(data).stream()
+                            .limit(20)
+                            .map(this::toAnimeEntity)
+                            .collect(Collectors.toList());
+
+            // saveAll as a batch
+            animeRepository.saveAll(animeList);
+            return animeList;
+
+        } catch (JsonProcessingException e) {
+            // TODO: replace with a proper logger
+            System.err.println("Failed parsing Jikan response: " + e.getMessage());
+            return List.of();
+        }
     }
 
     public Anime getAnimeById(Long id) {
         return animeRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Anime not found with id: " + id));
+                .orElseThrow(() -> new RuntimeException("Anime not found: " + id));
     }
 
-    // Placeholder for sample data, I gave up lol
-    public void initializeSampleData() {
-        if (animeRepository.count() == 0) {
-            createSampleAnime("Solo Leveling", "Ore dake Level Up na Ken", "/pics/Solo-Leveling.jpg");
-            createSampleAnime("The Apothecary Diaries", "Kusuriya no Hitorigoto", "/pics/The-Apothecary-Diaries.jpg");
-            createSampleAnime("One Piece", "One Piece", "/pics/One-Piece.jpg");
-            createSampleAnime("Re:ZERO - Starting Life in Another World", "Re:Zero kara Hajimeru Isekai Seikatsu", "/pics/ReZero.jpg");
-            createSampleAnime("Orb: On the Movements of the Earth", "Chi. Chikyuu no Undou ni Tsuite", "/pics/Orb.jpg");
-            createSampleAnime("Shangri-La Frontier", "Shangri-La Frontier: Kusoge Hunter, Kamige ni Idoman to su", "/pics/Shangri-La-Frontier.jpg");
-            createSampleAnime("Dr. Stone", "Dr. Stone: Science Future", "/pics/Dr.Stone.jpg");
-        }
+    // -- private helpers -----------------------------------------
+
+    /** Converts a JsonNode into your Anime entity. */
+    private Anime toAnimeEntity(JsonNode node) {
+        Anime a = new Anime();
+        a.setExternalId(node.path("mal_id").asLong());
+        a.setTitle(node.path("title").asText(null));
+        a.setAlternateTitle(node.path("title_japanese").asText(null));
+        a.setImageUrl(node.path("images")
+                .path("webp")
+                .path("large_image_url")
+                .asText());
+        return a;
     }
 
-    private void createSampleAnime(String title, String alternateTitle, String imageUrl) {
-        Anime anime = new Anime();
-        anime.setTitle(title);
-        anime.setAlternateTitle(alternateTitle);
-        anime.setImageUrl(imageUrl);
-        animeRepository.save(anime);
+    /** Utility to turn a JsonNode iterable into a List<JsonNode>. */
+    private List<JsonNode> toList(JsonNode arrayNode) {
+        return StreamSupport.stream(arrayNode.spliterator(), false)
+                .collect(Collectors.toList());
     }
 }

--- a/aniwatch(Rework-Jikarti)/aniwatch/src/main/java/com/aniwatch/aniwatch/config/AppConfig.java
+++ b/aniwatch(Rework-Jikarti)/aniwatch/src/main/java/com/aniwatch/aniwatch/config/AppConfig.java
@@ -1,0 +1,14 @@
+// src/main/java/com/aniwatch/aniwatch/config/AppConfig.java
+package com.aniwatch.aniwatch.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/aniwatch(Rework-Jikarti)/aniwatch/src/main/resources/templates/browse-anime.ftlh
+++ b/aniwatch(Rework-Jikarti)/aniwatch/src/main/resources/templates/browse-anime.ftlh
@@ -1,12 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>AniWatch - Browse Anime</title>
 
   <!-- Stylesheets -->
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
+    rel="stylesheet" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.css" />
@@ -100,41 +102,41 @@
     }
 
     .dropdown {
-                  position: relative;
-                  display: inline-block;
-                  margin-bottom: 11px;
-                }
+      position: relative;
+      display: inline-block;
+      margin-bottom: 11px;
+    }
 
-                .dropdown-menu {
-                  display: none;
-                  position: absolute;
-                  background-color: #222!important;
-                  min-width: 160px;
-                  box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
-                  z-index: 1;
-                  border-radius: 8px;
-                  margin-top: 4px!important;
-                  margin-right: -84px!important;
-                }
+    .dropdown-menu {
+      display: none;
+      position: absolute;
+      background-color: #222 !important;
+      min-width: 160px;
+      box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);
+      z-index: 1;
+      border-radius: 8px;
+      margin-top: 4px !important;
+      margin-right: -84px !important;
+    }
 
-                .dropdown:hover .dropdown-menu {
-                  display: block;
-                }
+    .dropdown:hover .dropdown-menu {
+      display: block;
+    }
 
-                .dropdown-menu a {
-                  color: white;
-                  padding: 12px 16px;
-                  text-decoration: none;
-                  display: block;
-                }
+    .dropdown-menu a {
+      color: white;
+      padding: 12px 16px;
+      text-decoration: none;
+      display: block;
+    }
 
-                .dropdown-menu a:hover {
-                  background-color: #495057;
-                }
+    .dropdown-menu a:hover {
+      background-color: #495057;
+    }
 
-                .fa-user {
-                margin-top: 14.5px;
-                }
+    .fa-user {
+      margin-top: 14.5px;
+    }
 
     /* Content Styles */
     .content {
@@ -412,6 +414,7 @@
         opacity: 0;
         transform: translateY(20px);
       }
+
       to {
         opacity: 1;
         transform: translateY(0);
@@ -464,148 +467,153 @@
 <body>
   <#import "/fragments/auth-modals.ftlh" as auth>
 
-  <!-- Top Navigation Bar -->
-  <div class="topnav">
-    <a href="/home" class="logo-link">
-      <h1 class="logo">AniWatch</h1>
-    </a>
-    <div class="nav-links">
-      <#if isAuthenticated?? && isAuthenticated>
-        <div class="dropdown">
-          <a href="#" class="dropbtn">
-            <i class="fas fa-user"></i> ${username!}
-          </a>
-          <div class="dropdown-menu">
-            <#if isProvider?? && isProvider>
-              <a href="/provider-profile/${providerId!}">My Profile</a>
-              <a href="/watchlists/new">Create Watchlist</a>
-            <#else>
-              <a href="/user-profile/${userId!}">My Profile</a>
-            </#if>
-            <a href="/logout">Logout</a>
+    <!-- Top Navigation Bar -->
+    <div class="topnav">
+      <a href="/home" class="logo-link">
+        <h1 class="logo">AniWatch</h1>
+      </a>
+      <div class="nav-links">
+        <#if isAuthenticated?? && isAuthenticated>
+          <div class="dropdown">
+            <a href="#" class="dropbtn">
+              <i class="fas fa-user"></i> ${username!}
+            </a>
+            <div class="dropdown-menu">
+              <#if isProvider?? && isProvider>
+                <a href="/provider-profile/${providerId!}">My Profile</a>
+                <a href="/watchlists/new">Create Watchlist</a>
+                <#else>
+                  <a href="/user-profile/${userId!}">My Profile</a>
+              </#if>
+              <a href="/logout">Logout</a>
+            </div>
           </div>
-        </div>
-      <#else>
-        <a href="#" data-bs-toggle="modal" data-bs-target="#loginModal">Login</a>
-      </#if>
-      <a href="/watchlists/watchlist-list">Watchlist library</a>
+          <#else>
+            <a href="#" data-bs-toggle="modal" data-bs-target="#loginModal">Login</a>
+        </#if>
+        <a href="/watchlists/watchlist-list">Watchlist library</a>
+      </div>
     </div>
-  </div>
 
-  <!-- Main Content -->
-  <div class="content">
-    <div class="container">
-      <div class="page-header">
-        <h2>Browse Anime</h2>
-        <p>Discover anime to add to your watchlists</p>
-      </div>
+    <!-- Main Content -->
+    <div class="content">
+      <div class="container">
+        <div class="page-header">
+          <h2>Browse Anime</h2>
+          <p>Discover anime to add to your watchlists</p>
+        </div>
 
-      <!-- Search Bar -->
-      <div class="search-bar">
-        <input type="text" id="searchInput" class="form-control" placeholder="Search anime by title, genre, or studio..." />
-      </div>
+        <!-- Search Bar -->
+        <div class="search-bar">
+          <input type="text" id="searchInput" class="form-control"
+            placeholder="Search anime by title, genre, or studio..." />
+        </div>
 
-      <!-- Anime Suggestions Section -->
-      <div class="section-heading">
-        <h2>Your Anime Suggestions</h2>
-      </div>
+        <!-- Anime Suggestions Section -->
+        <div class="section-heading">
+          <h2>Your Anime Suggestions</h2>
+        </div>
 
-      <div class="swiper mySwiper">
-        <div class="swiper-wrapper">
-          <#if animeList?has_content>
-            <#list animeList as anime>
-              <div class="swiper-slide">
-                <div class="anime-card">
-                  <img src="${anime.imageUrl}" alt="${anime.title}" />
-                  <div class="card-body">
-                    <h5 class="card-title">${anime.title}</h5>
-                    <p class="card-text">Alternate Title: ${anime.alternateTitle}</p>
+        <div class="swiper mySwiper">
+          <div class="swiper-wrapper">
+            <#if animeList?has_content>
+              <#list animeList as anime>
+                <div class="swiper-slide">
+                  <div class="anime-card">
+                    <img src="${anime.imageUrl!'/pics/default-anime.jpg'}" srcset="
+    ${anime.imageUrl!''}   1x,
+    ${anime.imageUrl?replace('.jpg','@2x.jpg')!''} 2x
+  " alt="${anime.title!}" loading="lazy" />
+                    <div class="card-body">
+                      <h5 class="card-title">${anime.title}</h5>
+                      <p class="card-text">Alternate Title: ${anime.alternateTitle}</p>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </#list>
-          <#else>
-            <div class="col-12 text-center">
-              <p>No anime available at the moment.</p>
-            </div>
-          </#if>
+              </#list>
+              <#else>
+                <div class="col-12 text-center">
+                  <p>No anime available at the moment.</p>
+                </div>
+            </#if>
+          </div>
+          <div class="swiper-button-next"></div>
+          <div class="swiper-button-prev"></div>
         </div>
-        <div class="swiper-button-next"></div>
-        <div class="swiper-button-prev"></div>
-      </div>
 
-      <!-- Genres Section -->
-      <div class="genres-section">
-        <div class="section-heading">
-          <h2>Explore by Genre</h2>
-        </div>
-        <div class="genres-grid">
-          <a href="#"><span>></span>Action</a>
-          <a href="#"><span>></span>Adventure</a>
-          <a href="#"><span>></span>Avant Garde</a>
-          <a href="#"><span>></span>Award Winning</a>
-          <a href="#"><span>></span>Boys Love</a>
-          <a href="#"><span>></span>Comedy</a>
-          <a href="#"><span>></span>Drama</a>
-          <a href="#"><span>></span>Fantasy</a>
-          <a href="#"><span>></span>Girls Love</a>
-          <a href="#"><span>></span>Gourmet</a>
-          <a href="#"><span>></span>Horror</a>
-          <a href="#"><span>></span>Mystery</a>
-          <a href="#"><span>></span>Romance</a>
-          <a href="#"><span>></span>Sci-Fi</a>
-          <a href="#"><span>></span>Slice of Life</a>
-          <a href="#"><span>></span>Sports</a>
-          <a href="#"><span>></span>Supernatural</a>
-          <a href="#"><span>></span>Suspense</a>
-          <a href="#"><span>></span>Isekai</a>
-          <a href="#"><span>></span>Place-holder</a>
+        <!-- Genres Section -->
+        <div class="genres-section">
+          <div class="section-heading">
+            <h2>Explore by Genre</h2>
+          </div>
+          <div class="genres-grid">
+            <a href="#"><span>></span>Action</a>
+            <a href="#"><span>></span>Adventure</a>
+            <a href="#"><span>></span>Avant Garde</a>
+            <a href="#"><span>></span>Award Winning</a>
+            <a href="#"><span>></span>Boys Love</a>
+            <a href="#"><span>></span>Comedy</a>
+            <a href="#"><span>></span>Drama</a>
+            <a href="#"><span>></span>Fantasy</a>
+            <a href="#"><span>></span>Girls Love</a>
+            <a href="#"><span>></span>Gourmet</a>
+            <a href="#"><span>></span>Horror</a>
+            <a href="#"><span>></span>Mystery</a>
+            <a href="#"><span>></span>Romance</a>
+            <a href="#"><span>></span>Sci-Fi</a>
+            <a href="#"><span>></span>Slice of Life</a>
+            <a href="#"><span>></span>Sports</a>
+            <a href="#"><span>></span>Supernatural</a>
+            <a href="#"><span>></span>Suspense</a>
+            <a href="#"><span>></span>Isekai</a>
+            <a href="#"><span>></span>Place-holder</a>
+          </div>
         </div>
       </div>
     </div>
-  </div>
 
-  <!-- Footer -->
-  <footer class="footer-section">
-    <div class="container">
-      <div class="social-links">
-        <a href="https://discord.com/" target="_blank">
-          <img src="/pics/discord-logo.png" alt="Discord" />
-        </a>
-        <a href="https://www.instagram.com/" target="_blank">
-          <img src="/pics/instagram-logo.png" alt="Instagram" />
-        </a>
-        <a href="https://www.reddit.com/" target="_blank">
-          <img src="/pics/reddit-logo.jpeg" alt="Reddit" />
-        </a>
-        <a href="https://twitter.com/" target="_blank">
-          <img src="/pics/x-logo.jpeg" alt="Twitter" />
-        </a>
+    <!-- Footer -->
+    <footer class="footer-section">
+      <div class="container">
+        <div class="social-links">
+          <a href="https://discord.com/" target="_blank">
+            <img src="/pics/discord-logo.png" alt="Discord" />
+          </a>
+          <a href="https://www.instagram.com/" target="_blank">
+            <img src="/pics/instagram-logo.png" alt="Instagram" />
+          </a>
+          <a href="https://www.reddit.com/" target="_blank">
+            <img src="/pics/reddit-logo.jpeg" alt="Reddit" />
+          </a>
+          <a href="https://twitter.com/" target="_blank">
+            <img src="/pics/x-logo.jpeg" alt="Twitter" />
+          </a>
+        </div>
+        <p>&copy; 2025 AniWatch</p>
       </div>
-      <p>&copy; 2025 AniWatch</p>
-    </div>
-  </footer>
+    </footer>
 
-  <!-- Auth Modals -->
-  <@auth.authModals/>
+    <!-- Auth Modals -->
+    <@auth.authModals />
 
-  <!-- Scripts -->
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js"></script>
-  <script src="/js/main.js"></script>
-  <script src="/js/login-registration.js"></script>
+    <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js"></script>
+    <script src="/js/main.js"></script>
+    <script src="/js/login-registration.js"></script>
 
-  <script>
-    document.addEventListener('DOMContentLoaded', function() {
-      // Search functionality
-      const searchInput = document.getElementById('searchInput');
-      if (searchInput) {
-        searchInput.addEventListener('input', function() {
-          // Add search functionality here
-          // This would typically filter anime cards based on search input
-        });
-      }
-    });
-  </script>
+    <script>
+      document.addEventListener('DOMContentLoaded', function () {
+        // Search functionality
+        const searchInput = document.getElementById('searchInput');
+        if (searchInput) {
+          searchInput.addEventListener('input', function () {
+            // Add search functionality here
+            // This would typically filter anime cards based on search input
+          });
+        }
+      });
+    </script>
 </body>
+
 </html>

--- a/aniwatch(Rework-Jikarti)/aniwatch/src/main/resources/templates/home.ftlh
+++ b/aniwatch(Rework-Jikarti)/aniwatch/src/main/resources/templates/home.ftlh
@@ -99,41 +99,41 @@
     }
 
     .dropdown {
-              position: relative;
-              display: inline-block;
-              margin-bottom: 11px;
-            }
+      position: relative;
+      display: inline-block;
+      margin-bottom: 11px;
+    }
 
-            .dropdown-menu {
-              display: none;
-              position: absolute;
-              background-color: #222!important;
-              min-width: 160px;
-              box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
-              z-index: 1;
-              border-radius: 8px;
-              margin-top: 4px!important;
-              margin-right: -84px!important;
-            }
+    .dropdown-menu {
+      display: none;
+      position: absolute;
+      background-color: #222 !important;
+      min-width: 160px;
+      box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);
+      z-index: 1;
+      border-radius: 8px;
+      margin-top: 4px !important;
+      margin-right: -84px !important;
+    }
 
-            .dropdown:hover .dropdown-menu {
-              display: block;
-            }
+    .dropdown:hover .dropdown-menu {
+      display: block;
+    }
 
-            .dropdown-menu a {
-              color: white;
-              padding: 12px 16px;
-              text-decoration: none;
-              display: block;
-            }
+    .dropdown-menu a {
+      color: white;
+      padding: 12px 16px;
+      text-decoration: none;
+      display: block;
+    }
 
-            .dropdown-menu a:hover {
-              background-color: #495057;
-            }
+    .dropdown-menu a:hover {
+      background-color: #495057;
+    }
 
-            .fa-user {
-            margin-top: 14.5px;
-            }
+    .fa-user {
+      margin-top: 14.5px;
+    }
 
     /* Content Styles */
     .content {
@@ -212,55 +212,55 @@
 
     /* Cards */
     .anime-card {
-          background: linear-gradient(135deg, rgba(44, 62, 80, 0.7) 0%, rgba(52, 73, 94, 0.7) 100%);
-          border-radius: 12px;
-          overflow: hidden;
-          transition: all 0.3s ease;
-          height: 100%;
-          border: 1px solid rgba(255, 255, 255, 0.1);
-          box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2);
-          margin-bottom: 20px;
-        }
+      background: linear-gradient(135deg, rgba(44, 62, 80, 0.7) 0%, rgba(52, 73, 94, 0.7) 100%);
+      border-radius: 12px;
+      overflow: hidden;
+      transition: all 0.3s ease;
+      height: 100%;
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2);
+      margin-bottom: 20px;
+    }
 
-        .anime-card:hover {
-          transform: translateY(-10px);
-          box-shadow: 0 15px 30px rgba(0, 0, 0, 0.3);
-          border-color: rgba(52, 152, 219, 0.3);
-        }
+    .anime-card:hover {
+      transform: translateY(-10px);
+      box-shadow: 0 15px 30px rgba(0, 0, 0, 0.3);
+      border-color: rgba(52, 152, 219, 0.3);
+    }
 
-        .anime-card img {
-          width: 100%;
-          height: 350px;
-          object-fit: cover;
-          transition: all 0.5s;
-        }
+    .anime-card img {
+      width: 100%;
+      height: 350px;
+      object-fit: cover;
+      transition: all 0.5s;
+    }
 
-        .anime-card:hover img {
-          transform: scale(1.05);
-        }
+    .anime-card:hover img {
+      transform: scale(1.05);
+    }
 
-        .anime-card .card-body {
-          padding: 20px;
-          background: rgba(26, 30, 37, 0.9);
-        }
+    .anime-card .card-body {
+      padding: 20px;
+      background: rgba(26, 30, 37, 0.9);
+    }
 
-        .anime-card .card-title {
-          font-size: 18px;
-          font-weight: 600;
-          margin-bottom: 8px;
-          color: var(--text-light);
-          overflow: hidden;
-          text-overflow: ellipsis;
-          white-space: nowrap;
-        }
+    .anime-card .card-title {
+      font-size: 18px;
+      font-weight: 600;
+      margin-bottom: 8px;
+      color: var(--text-light);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
 
-        .anime-card .card-text {
-          font-size: 14px;
-          color: var(--text-muted);
-          overflow: hidden;
-          text-overflow: ellipsis;
-          white-space: nowrap;
-        }
+    .anime-card .card-text {
+      font-size: 14px;
+      color: var(--text-muted);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
 
     /* Watchlist Card */
     .watchlist-card {
@@ -303,15 +303,15 @@
     }
 
     .provider-info a {
-          color: var(--text-light);
-          text-decoration: none;
-          font-weight: 600;
-          transition: all 0.3s;
-        }
+      color: var(--text-light);
+      text-decoration: none;
+      font-weight: 600;
+      transition: all 0.3s;
+    }
 
-        .provider-info a:hover {
-          color: var(--primary-color);
-        }
+    .provider-info a:hover {
+      color: var(--primary-color);
+    }
 
     .watchlist-card-title {
       font-size: 18px;
@@ -595,356 +595,302 @@
 <body>
   <#import "/fragments/auth-modals.ftlh" as auth>
 
-  <!-- Top Navigation Bar -->
-  <div class="topnav">
-          <a href="/home" class="logo-link">
-              <h1 class="logo">AniWatch</h1>
-          </a>
-          <div class="nav-links">
-              <#if isAuthenticated?? && isAuthenticated>
-                  <div class="dropdown">
-                      <a href="#" class="dropbtn">
-                          <i class="fas fa-user"></i> ${username!}
-                      </a>
-                      <div class="dropdown-menu">
-                          <#if isProvider?? && isProvider>
-                              <a href="/provider-profile/${providerId!}">My Profile</a>
-                              <a href="/watchlists/new">Create Watchlist</a>
-                          <#else>
-                              <a href="/user-profile/${userId!}">My Profile</a>
-                          </#if>
-                          <a href="/logout">Logout</a>
+    <!-- Top Navigation Bar -->
+    <div class="topnav">
+      <a href="/home" class="logo-link">
+        <h1 class="logo">AniWatch</h1>
+      </a>
+      <div class="nav-links">
+        <#if isAuthenticated?? && isAuthenticated>
+          <div class="dropdown">
+            <a href="#" class="dropbtn">
+              <i class="fas fa-user"></i> ${username!}
+            </a>
+            <div class="dropdown-menu">
+              <#if isProvider?? && isProvider>
+                <a href="/provider-profile/${providerId!}">My Profile</a>
+                <a href="/watchlists/new">Create Watchlist</a>
+                <#else>
+                  <a href="/user-profile/${userId!}">My Profile</a>
+              </#if>
+              <a href="/logout">Logout</a>
+            </div>
+          </div>
+          <a href="/watchlists/watchlist-list">Watchlists library</a>
+          <a href="/browse-anime">Browse Anime</a>
+          <#else>
+            <a href="#" data-bs-toggle="modal" data-bs-target="#loginModal">Login</a>
+            <a href="/watchlists/watchlist-list">Watchlists library</a>
+            <a href="/browse-anime">Browse Anime</a>
+        </#if>
+      </div>
+    </div>
+
+    <!-- Main Content -->
+    <div class="content">
+      <!-- Hero Section -->
+      <div class="container">
+        <div class="hero-section">
+          <div class="hero-content text-center">
+            <h1>Discover and track your favorite anime and manga!</h1>
+            <p>Join our community of anime enthusiasts to create, share and discover the best watchlists.</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Anime Data Section -->
+      <div class="container">
+        <div class="section-heading">
+          <h2>Popular ${currentSeason} Anime</h2>
+          <p>Trending series this season that everyone’s watching</p>
+        </div>
+
+        <div class="swiper mySwiper">
+          <div class="swiper-wrapper">
+            <#-- if we have API data -->
+              <#if seasonalAnime?has_content>
+                <#list seasonalAnime as anime>
+                  <div class="swiper-slide">
+                    <div class="anime-card">
+                      <img src="${anime.imageUrl!'/pics/default-anime.jpg'}" srcset="
+                      ${anime.imageUrl!''}   1x,
+                      ${anime.imageUrl?replace('.jpg','@2x.jpg')!''} 2x
+                    " alt="${anime.title!}" loading="lazy" />
+                      <div class="card-body">
+                        <h5 class="card-title">${anime.title! 'Untitled'}</h5>
+                        <p class="card-text">
+                          Alternate: ${anime.alternateTitle! '—'}
+                        </p>
                       </div>
+                    </div>
                   </div>
-                  <a href="/watchlists/watchlist-list">Watchlists library</a>
-                  <a href="/browse-anime">Browse Anime</a>
-              <#else>
-                  <a href="#" data-bs-toggle="modal" data-bs-target="#loginModal">Login</a>
-                  <a href="/watchlists/watchlist-list">Watchlists library</a>
-                  <a href="/browse-anime">Browse Anime</a>
+                </#list>
+                <#else>
+                  <div class="col-12 text-center">
+                    <p class="text-muted">No anime available at the moment.</p>
+                  </div>
               </#if>
           </div>
-      </div>
 
-  <!-- Main Content -->
-  <div class="content">
-    <!-- Hero Section -->
-    <div class="container">
-      <div class="hero-section">
-        <div class="hero-content text-center">
-          <h1>Discover and track your favorite anime and manga!</h1>
-          <p>Join our community of anime enthusiasts to create, share and discover the best watchlists.</p>
+          <div class="swiper-button-next"></div>
+          <div class="swiper-button-prev"></div>
         </div>
       </div>
-    </div>
 
-    <!-- Anime Data Section -->
-    <div class="container">
-      <div class="section-heading">
-        <h2>Popular ${currentSeason} Anime</h2>
-        <p>Trending series this season that everyone's watching</p>
-      </div>
 
-      <div class="swiper mySwiper">
-        <div class="swiper-wrapper">
-          <div class="swiper-slide">
-            <div class="anime-card">
-              <div class="card-img-container">
-                <img src="/pics/Solo-Leveling.jpg" alt="Solo Leveling">
-              </div>
-              <div class="card-body">
-                <h5 class="card-title">Solo Leveling</h5>
-                <p class="card-text">Alternate Title: Ore dake Level Up na Ken</p>
-              </div>
-            </div>
-          </div>
-
-          <div class="swiper-slide">
-            <div class="anime-card">
-              <div class="card-img-container">
-                <img src="/pics/The-Apothecary-Diaries.jpg" alt="The Apothecary Diaries">
-              </div>
-              <div class="card-body">
-                <h5 class="card-title">The Apothecary Diaries</h5>
-                <p class="card-text">Alternate Title: Kusuriya no Hitorigoto</p>
-              </div>
-            </div>
-          </div>
-
-          <div class="swiper-slide">
-            <div class="anime-card">
-              <div class="card-img-container">
-                <img src="/pics/One-Piece.jpg" alt="One Piece">
-              </div>
-              <div class="card-body">
-                <h5 class="card-title">One Piece</h5>
-                <p class="card-text">Alternate Title: One Piece</p>
-              </div>
-            </div>
-          </div>
-
-          <div class="swiper-slide">
-            <div class="anime-card">
-              <div class="card-img-container">
-                <img src="/pics/ReZero.jpg" alt="Re:Zero">
-              </div>
-              <div class="card-body">
-                <h5 class="card-title">Re:ZERO - Starting Life in Another World</h5>
-                <p class="card-text">Alternate Title: Re:Zero kara Hajimeru Isekai Seikatsu</p>
-              </div>
-            </div>
-          </div>
-
-          <div class="swiper-slide">
-            <div class="anime-card">
-              <div class="card-img-container">
-                <img src="/pics/Orb.jpg" alt="Orb: On the Movements of the Earth">
-              </div>
-              <div class="card-body">
-                <h5 class="card-title">Orb: On the Movements of the Earth</h5>
-                <p class="card-text">Alternate Title: Chi. Chikyuu no Undou ni Tsuite</p>
-              </div>
-            </div>
-          </div>
-
-          <div class="swiper-slide">
-            <div class="anime-card">
-              <div class="card-img-container">
-                <img src="/pics/Shangri-La-Frontier.jpg" alt="Shangri-La Frontier">
-              </div>
-              <div class="card-body">
-                <h5 class="card-title">Shangri-La Frontier</h5>
-                <p class="card-text">Alternate Title: Shangri-La Frontier: Kusoge Hunter, Kamige ni Idoman to su</p>
-              </div>
-            </div>
-          </div>
-
-          <div class="swiper-slide">
-            <div class="anime-card">
-              <div class="card-img-container">
-                <img src="/pics/Dr.Stone.jpg" alt="Dr. Stone">
-              </div>
-              <div class="card-body">
-                <h5 class="card-title">Dr. Stone</h5>
-                <p class="card-text">Alternate Title: Dr. Stone: Science Future</p>
-              </div>
-            </div>
+      <!-- Welcome Section -->
+      <div class="container">
+        <div class="welcome-section">
+          <div class="welcome-content">
+            <h2>Welcome to AniWatch</h2>
+            <p>Find the Anime Watchlist that fits exactly what you're looking for!</p>
           </div>
         </div>
-
-        <div class="swiper-button-next"></div>
-        <div class="swiper-button-prev"></div>
       </div>
-    </div>
 
-    <!-- Welcome Section -->
-    <div class="container">
-      <div class="welcome-section">
-        <div class="welcome-content">
-          <h2>Welcome to AniWatch</h2>
-          <p>Find the Anime Watchlist that fits exactly what you're looking for!</p>
+      <!-- Featured Watchlists Section -->
+      <div class="container">
+        <div class="section-heading">
+          <h2>Featured Watchlists</h2>
+          <p>Curated collections from our top providers</p>
         </div>
-      </div>
-    </div>
 
-    <!-- Featured Watchlists Section -->
-    <div class="container">
-      <div class="section-heading">
-        <h2>Featured Watchlists</h2>
-        <p>Curated collections from our top providers</p>
-      </div>
-
-      <div class="swiper mySwiper2">
-        <div class="swiper-wrapper">
-          <#if featuredWatchlists?has_content>
-            <#list featuredWatchlists as watchlist>
-              <div class="swiper-slide watchlist-item">
-                <div class="watchlist-card">
-                  <img src="${watchlist.thumbnail!'/pics/default-watchlist.jpg'}" alt="${watchlist.title}" class="watchlist-thumbnail" onerror="this.src='/pics/default-watchlist.jpg';">
-                  <div class="watchlist-card-body">
-                    <h5 class="watchlist-card-title">${watchlist.title}</h5>
-                    <div class="provider-info">
-                      <img src="${watchlist.avatar!'/pics/default-profile.jpg'}" alt="Provider" class="profile-image">
-                      <span class="watchlist-card-text">By: <a href="/provider-profile/${providerId!}" class="text-light">${watchlist.providerUsername}</a></span>
-                    </div>
-                    <div class="watchlist-metadata">
-                      <div class="views-counter">
-                        <i class="fas fa-eye"></i> ${watchlist.views!'0'} views
+        <div class="swiper mySwiper2">
+          <div class="swiper-wrapper">
+            <#if featuredWatchlists?has_content>
+              <#list featuredWatchlists as watchlist>
+                <div class="swiper-slide watchlist-item">
+                  <div class="watchlist-card">
+                    <img src="${watchlist.thumbnail!'/pics/default-watchlist.jpg'}" alt="${watchlist.title}"
+                      class="watchlist-thumbnail" onerror="this.src='/pics/default-watchlist.jpg';">
+                    <div class="watchlist-card-body">
+                      <h5 class="watchlist-card-title">${watchlist.title}</h5>
+                      <div class="provider-info">
+                        <img src="${watchlist.avatar!'/pics/default-profile.jpg'}" alt="Provider" class="profile-image">
+                        <span class="watchlist-card-text">By: <a href="/provider-profile/${providerId!}"
+                            class="text-light">${watchlist.providerUsername}</a></span>
                       </div>
-                      <div class="rating-container">
-                        <span class="text-warning">
-                          <#assign stars = (watchlist.rating?has_content && watchlist.rating gt 0)?then(watchlist.rating?round, 0)>
-                          <#list 1..5 as i>
-                            <#if i <= stars>★<#else>☆</#if>
-                          </#list>
-                        </span>
-                        (${(watchlist.rating?has_content)?then(watchlist.rating?string("0.0"), "0.0")}/5)
+                      <div class="watchlist-metadata">
+                        <div class="views-counter">
+                          <i class="fas fa-eye"></i> ${watchlist.views!'0'} views
+                        </div>
+                        <div class="rating-container">
+                          <span class="text-warning">
+                            <#assign stars=(watchlist.rating?has_content && watchlist.rating gt
+                              0)?then(watchlist.rating?round, 0)>
+                              <#list 1..5 as i>
+                                <#if i <=stars>★<#else>☆</#if>
+                              </#list>
+                          </span>
+                          (${(watchlist.rating?has_content)?then(watchlist.rating?string("0.0"), "0.0")}/5)
+                        </div>
                       </div>
+                      <#if isAuthenticated?? && isAuthenticated>
+                        <div class="btn-group">
+                          <a href="/watchlists/${watchlist.watchlistId}" class="btn btn-outline-light">View list</a>
+                          <button class="btn btn-primary"
+                            data-watchlist-id="${watchlist.watchlistId}">Subscribe</button>
+                        </div>
+                        <#else>
+                          <div class="btn-group">
+                            <a href="/watchlists/${watchlist.watchlistId}" class="btn btn-outline-light">View list</a>
+                          </div>
+                      </#if>
                     </div>
-                    <#if isAuthenticated?? && isAuthenticated>
-                                            <div class="btn-group">
-                                              <a href="/watchlists/${watchlist.watchlistId}" class="btn btn-outline-light">View list</a>
-                                              <button class="btn btn-primary" data-watchlist-id="${watchlist.watchlistId}">Subscribe</button>
-                                            </div>
-                                          <#else>
-                                            <div class="btn-group">
-                                              <a href="/watchlists/${watchlist.watchlistId}" class="btn btn-outline-light">View list</a>
-                                            </div>
-                                          </#if>
                   </div>
                 </div>
-              </div>
-            </#list>
-          <#else>
-            <div class="col-12 text-center">
-              <p class="text-muted">No watchlists available yet.</p>
-            </div>
-          </#if>
+              </#list>
+              <#else>
+                <div class="col-12 text-center">
+                  <p class="text-muted">No watchlists available yet.</p>
+                </div>
+            </#if>
+          </div>
+
+          <div class="swiper-button-next"></div>
+          <div class="swiper-button-prev"></div>
         </div>
-
-        <div class="swiper-button-next"></div>
-        <div class="swiper-button-prev"></div>
       </div>
     </div>
-  </div>
 
-  <!-- Footer -->
-  <footer class="footer-section">
-    <div class="container">
-      <div class="social-links">
-        <a href="https://discord.com/" target="_blank">
-          <img src="/pics/discord-logo.png" alt="Discord">
-        </a>
-        <a href="https://www.instagram.com/" target="_blank">
-          <img src="/pics/instagram-logo.png" alt="Instagram">
-        </a>
-        <a href="https://www.reddit.com/" target="_blank">
-          <img src="/pics/reddit-logo.jpeg" alt="Reddit">
-        </a>
-        <a href="https://twitter.com/" target="_blank">
-          <img src="/pics/x-logo.jpeg" alt="Twitter">
-        </a>
+    <!-- Footer -->
+    <footer class="footer-section">
+      <div class="container">
+        <div class="social-links">
+          <a href="https://discord.com/" target="_blank">
+            <img src="/pics/discord-logo.png" alt="Discord">
+          </a>
+          <a href="https://www.instagram.com/" target="_blank">
+            <img src="/pics/instagram-logo.png" alt="Instagram">
+          </a>
+          <a href="https://www.reddit.com/" target="_blank">
+            <img src="/pics/reddit-logo.jpeg" alt="Reddit">
+          </a>
+          <a href="https://twitter.com/" target="_blank">
+            <img src="/pics/x-logo.jpeg" alt="Twitter">
+          </a>
+        </div>
+        <p>&copy; 2025 AniWatch</p>
       </div>
-      <p>&copy; 2025 AniWatch</p>
-    </div>
-  </footer>
+    </footer>
 
-  <@auth.authModals/>
+    <@auth.authModals />
 
-  <script src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js"></script>
-  <script src="/js/main.js"></script>
-  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="/js/login-registration.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js"></script>
+    <script src="/js/main.js"></script>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="/js/login-registration.js"></script>
 
-  <script>
-    <#noparse>
+    <script>
+      <#noparse>
               // Subscription handling
-            document.addEventListener('DOMContentLoaded', function() {
+        document.addEventListener('DOMContentLoaded', function() {
               const subscribeButtons = document.querySelectorAll('.btn-primary');
 
               subscribeButtons.forEach(button => {
                 if (button.textContent === 'Subscribe') {
                   const watchlistId = button.getAttribute('data-watchlist-id');
 
-                  // Check if already subscribed
-                  fetch("/api/subscriptions/check/" + watchlistId)
+        // Check if already subscribed
+        fetch("/api/subscriptions/check/" + watchlistId)
                     .then(response => response.json())
                     .then(isSubscribed => {
                       if (isSubscribed) {
-                        button.textContent = 'Unsubscribe';
-                        button.classList.remove('btn-primary');
-                        button.classList.add('btn-danger');
+          button.textContent = 'Unsubscribe';
+        button.classList.remove('btn-primary');
+        button.classList.add('btn-danger');
                       }
                     })
                     .catch(error => {
-                      console.error('Error checking subscription status:', error);
+          console.error('Error checking subscription status:', error);
                     });
 
-                  // Add click handler
-                  button.addEventListener('click', function() {
+        // Add click handler
+        button.addEventListener('click', function() {
                     const isSubscribing = button.textContent === 'Subscribe';
-                    const endpoint = isSubscribing ?
-                      "/api/subscriptions/subscribe/" + watchlistId :
-                      "/api/subscriptions/unsubscribe/" + watchlistId;
+        const endpoint = isSubscribing ?
+        "/api/subscriptions/subscribe/" + watchlistId :
+        "/api/subscriptions/unsubscribe/" + watchlistId;
 
-                    fetch(endpoint, {
-                      method: 'POST'
+        fetch(endpoint, {
+          method: 'POST'
                     })
                     .then(response => {
                       if (response.ok) {
                         if (isSubscribing) {
-                          button.textContent = 'Unsubscribe';
-                          button.classList.remove('btn-primary');
-                          button.classList.add('btn-danger');
+          button.textContent = 'Unsubscribe';
+        button.classList.remove('btn-primary');
+        button.classList.add('btn-danger');
                         } else {
-                          button.textContent = 'Subscribe';
-                          button.classList.remove('btn-danger');
-                          button.classList.add('btn-primary');
+          button.textContent = 'Subscribe';
+        button.classList.remove('btn-danger');
+        button.classList.add('btn-primary');
                         }
                       }
                     })
                     .catch(error => {
-                      console.error('Error updating subscription:', error);
+          console.error('Error updating subscription:', error);
                     });
                   });
                 }
               });
 
-              // Handle unsubscribe buttons on profile page
-              const unsubscribeButtons = document.querySelectorAll('.unsubscribe-btn');
+        // Handle unsubscribe buttons on profile page
+        const unsubscribeButtons = document.querySelectorAll('.unsubscribe-btn');
               unsubscribeButtons.forEach(button => {
-                button.addEventListener('click', function() {
-                  const watchlistId = button.dataset.watchlistId;
+          button.addEventListener('click', function () {
+            const watchlistId = button.dataset.watchlistId;
 
-                  fetch("/api/subscriptions/unsubscribe/" + watchlistId, {
-                    method: 'POST'
-                  })
-                  .then(response => {
-                    if (response.ok) {
-                      // Remove the watchlist card from the display
-                      button.closest('.watchlist-item').remove();
+            fetch("/api/subscriptions/unsubscribe/" + watchlistId, {
+              method: 'POST'
+            })
+              .then(response => {
+                if (response.ok) {
+                  // Remove the watchlist card from the display
+                  button.closest('.watchlist-item').remove();
 
-                      // Update the subscription count
-                      const counterElement = document.querySelector('.stats-list .green + span');
-                      if (counterElement) {
-                        let count = parseInt(counterElement.textContent);
-                        counterElement.textContent = (count - 1).toString();
-                      }
-                    }
-                  });
-                });
+                  // Update the subscription count
+                  const counterElement = document.querySelector('.stats-list .green + span');
+                  if (counterElement) {
+                    let count = parseInt(counterElement.textContent);
+                    counterElement.textContent = (count - 1).toString();
+                  }
+                }
+              });
+          });
               });
 
-              // Add some animations
-              const animateOnScroll = function() {
+        // Add some animations
+        const animateOnScroll = function() {
                 const elements = document.querySelectorAll('.section-heading, .hero-content, .welcome-content');
 
                 elements.forEach(element => {
                   const elementPosition = element.getBoundingClientRect().top;
-                  const screenPosition = window.innerHeight / 1.3;
+        const screenPosition = window.innerHeight / 1.3;
 
-                  if (elementPosition < screenPosition) {
-                    element.style.opacity = '1';
-                    element.style.transform = 'translateY(0)';
+        if (elementPosition < screenPosition) {
+          element.style.opacity = '1';
+        element.style.transform = 'translateY(0)';
                   }
                 });
               };
 
               // Set initial styles for animation
               document.querySelectorAll('.section-heading, .hero-content, .welcome-content').forEach(element => {
-                element.style.opacity = '0';
-                element.style.transform = 'translateY(20px)';
-                element.style.transition = 'all 0.8s ease-out';
+          element.style.opacity = '0';
+        element.style.transform = 'translateY(20px)';
+        element.style.transition = 'all 0.8s ease-out';
               });
 
-              // Run once on load
-              animateOnScroll();
+        // Run once on load
+        animateOnScroll();
 
-              // Add scroll event listener
-              window.addEventListener('scroll', animateOnScroll);
+        // Add scroll event listener
+        window.addEventListener('scroll', animateOnScroll);
             });
-            </#noparse>
-          </script>
-        </body>
-        </html>
+      </#noparse>
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
- Add RestTemplate bean in AppConfig for centralized HTTP client injection
- Refactor AnimeService: • fetchAndSaveTopAnime(): batch-save top 20 anime from Jikan API (display limited to 10) • fetchSeasonalAnime(): on-the-fly fetch of seasonal anime without persisting to DB • Simplify JSON-to-Anime mapping to use API’s title fields directly
- Update Anime entity: • Introduce externalId (mal_id) field alongside auto-generated DB ID • Remove sample data initializers and placeholders
- Update AnimeController & HomeController: • Inject AnimeService and call its new methods • Replace static placeholders with API-driven model attributes (animeList → seasonalAnime) • Ensure currentSeason is always set and added to model
- Update FreeMarker templates (browse-anime.ftlh, home.ftlh): • Swap hard-coded slides for <#list> loops over animeList/seasonalAnime • Add image and title fallbacks in template via FreeMarker defaults

✅ `/browse-anime` and `/home` now load real Jikan data dynamically, with simplified mapping logic.